### PR TITLE
Add GitHub Actions workflow for creating releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Taskfile
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.14"
+
+      - name: Build project
+        run: task go:build
+
+      - name: Create Github Release and upload artifacts
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: parser


### PR DESCRIPTION
On every tag pushed to the repository with a version format, build the project, create a GitHub release, and upload the
executable as a release artifact.

You can see a test release here:
https://github.com/per1234/library-manager-submission-parser/releases/tag/untagged-eba86abf178ec32f8220
This got a little bit strange because I deleted the tag. But maybe it is still beneficial for the reviewers.
It will be deleted before the repository visibility is changed to public.