### PR TITLE
Add CI workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,8 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =
+skip = ./.git,go.mod,go.sum,parser,parser.exe

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,36 @@
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Taskfile
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Spell check
+        run: task general:check-spelling

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Arduino Library Manager submission parser
 
+[![Spell Check status](https://github.com/arduino/library-manager-submission-parser/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino/library-manager-submission-parser/actions/workflows/spell-check.yml)
+
 This is the tool used to parse submissions to [the Arduino Library Manager registry](https://github.com/arduino/library-manager-registry).
 
 ## Security

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,6 +10,7 @@ tasks:
     desc: Check for problems with the project
     deps:
       - task: go:test
+      - task: general:check-spelling
 
   go:build:
     desc: Build the project
@@ -21,3 +22,14 @@ tasks:
     cmds:
       - go test -v -short -run '{{default ".*" .GO_TEST_REGEX}}' {{default "-timeout 10m -coverpkg=./... -covermode=atomic" .GO_TEST_FLAGS}} -coverprofile=coverage_unit.txt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
+  general:check-spelling:
+    desc: Check for commonly misspelled words
+    cmds:
+      - poetry install --no-root
+      - poetry run codespell {{.CODESPELL_SKIP_OPTION}} {{.CODESPELL_IGNORE_WORDS_OPTION}}
+
+  general:correct-spelling:
+    desc: Correct commonly misspelled words where possible
+    cmds:
+      - poetry install --no-root
+      - poetry run codespell --write-changes {{.CODESPELL_SKIP_OPTION}} {{.CODESPELL_IGNORE_WORDS_OPTION}}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,22 @@
+[[package]]
+category = "dev"
+description = "Codespell"
+name = "codespell"
+optional = false
+python-versions = ">=3.5"
+version = "2.0.0"
+
+[package.extras]
+dev = ["check-manifest", "flake8", "pytest", "pytest-cov", "pytest-dependency"]
+hard-encoding-detection = ["chardet"]
+
+[metadata]
+content-hash = "04bfba866bc7b58afdfc851fc8ec7e13967445b6124f0a03e78e8fdedd70c6e3"
+lock-version = "1.0"
+python-versions = "^3.8"
+
+[metadata.files]
+codespell = [
+    {file = "codespell-2.0.0-py3-none-any.whl", hash = "sha256:a10b8bbb9f678e4edff7877af1f654fdc9e27c205f952c3ddee2981ad02ec5f2"},
+    {file = "codespell-2.0.0.tar.gz", hash = "sha256:dd9983e096b9f7ba89dd2d2466d1fc37231d060f19066331b9571341363c77b8"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.poetry]
+name = "library-manager-submission-parser"
+version = "0.0.0"
+description = "Arduino Library Manager submission parser"
+authors = ["Arduino <info@arduino.cc>"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+
+[tool.poetry.dev-dependencies]
+codespell = ">=2.0.0"


### PR DESCRIPTION
On every push, pull request, and periodically, use the codespell-project/actions-codespell action to check for commonly
misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the ignore-words-list field
of `./.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore
list. The ignore list is comma-separated with no spaces.