### PR TITLE
Add CI workflow to lint and check formatting of Go code

### DIFF
--- a/.github/workflows/check-go.yml
+++ b/.github/workflows/check-go.yml
@@ -1,0 +1,71 @@
+name: Check Go
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-go.yml"
+      - "Taskfile.yml"
+      - "**.go"
+  pull_request:
+    paths:
+      - ".github/workflows/check-go.yml"
+      - "Taskfile.yml"
+      - "**.go"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to tools.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check-errors:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Taskfile
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check for errors
+        run: task go:vet
+
+  check-style:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Taskfile
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check style
+        run: task go:lint
+
+  check-formatting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Taskfile
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Format code
+        run: task go:format
+
+      - name: Check formatting
+        run: git diff --color --exit-code

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Arduino Library Manager submission parser
 
+[![Check Go status](https://github.com/arduino/library-manager-submission-parser/actions/workflows/check-go.yml/badge.svg)](https://github.com/arduino/library-manager-submission-parser/actions/workflows/check-go.yml)
 [![Check Prettier Formatting status](https://github.com/arduino/library-manager-submission-parser/actions/workflows/check-prettier-formatting.yml/badge.svg)](https://github.com/arduino/library-manager-submission-parser/actions/workflows/check-prettier-formatting.yml)
 [![Spell Check status](https://github.com/arduino/library-manager-submission-parser/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino/library-manager-submission-parser/actions/workflows/spell-check.yml)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,8 +11,16 @@ tasks:
   check:
     desc: Check for problems with the project
     deps:
+      - task: go:vet
+      - task: go:lint
       - task: go:test
       - task: general:check-spelling
+
+  format:
+    desc: Format all files
+    deps:
+      - task: go:format
+      - task: general:format
 
   go:build:
     desc: Build the project
@@ -23,6 +31,26 @@ tasks:
     desc: Run unit tests
     cmds:
       - go test -v -short -run '{{default ".*" .GO_TEST_REGEX}}' {{default "-timeout 10m -coverpkg=./... -covermode=atomic" .GO_TEST_FLAGS}} -coverprofile=coverage_unit.txt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
+
+  go:vet:
+    desc: Check for errors in Go code
+    cmds:
+      - go vet {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
+
+  go:lint:
+    desc: Lint Go code
+    cmds:
+      - go get golang.org/x/lint/golint
+      - |
+        GOLINT_PATH="$(go list -f '{{"{{"}}.Target{{"}}"}}' golang.org/x/lint/golint || echo "false")"
+        "$GOLINT_PATH" \
+          {{default "-min_confidence 0.8 -set_exit_status" .GO_LINT_FLAGS}} \
+          {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
+
+  go:format:
+    desc: Format Go code
+    cmds:
+      - go fmt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   general:format:
     desc: Format all supported files with Prettier


### PR DESCRIPTION
On every push and pull request that affects relevant files, and periodically, lint and check formatting of the
repository's Go module.