### PR TITLE
Add check for submission URL being a Git repository

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,6 @@
 package main
 
 import (
-	"fmt"
 	"net/url"
 	"testing"
 
@@ -154,14 +153,11 @@ func Test_normalizeURL(t *testing.T) {
 		testName              string
 		rawURL                string
 		expectedNormalizedURL string
-		expectedError         string
 	}{
-		{"Trailing slash", "https://github.com/foo/bar/", "https://github.com/foo/bar.git", ""},
-		{".git suffix", "https://github.com/foo/bar.git", "https://github.com/foo/bar.git", ""},
-		{"Too few path elements", "https://github.com/foo", "", "Submission URL must point to the root of the repository"},
-		{"Too many path elements", "https://github.com/foo/bar/baz", "", "Submission URL must point to the root of the repository"},
-		{"http://", "http://github.com/foo/bar", "https://github.com/foo/bar.git", ""},
-		{"git://", "git://github.com/foo/bar", "https://github.com/foo/bar.git", ""},
+		{"Trailing slash", "https://github.com/foo/bar/", "https://github.com/foo/bar.git"},
+		{".git suffix", "https://github.com/foo/bar.git", "https://github.com/foo/bar.git"},
+		{"http://", "http://github.com/foo/bar", "https://github.com/foo/bar.git"},
+		{"git://", "git://github.com/foo/bar", "https://github.com/foo/bar.git"},
 	}
 
 	for _, testTable := range testTables {
@@ -170,13 +166,7 @@ func Test_normalizeURL(t *testing.T) {
 		expectedNormalizedURL, err := url.Parse(testTable.expectedNormalizedURL)
 		require.Nil(t, err)
 
-		normalizedURL, err := normalizeURL(rawURL)
-		assert.Equal(t, *expectedNormalizedURL, normalizedURL, testTable.testName)
-		if testTable.expectedError == "" {
-			assert.Nil(t, err, testTable.testName)
-		} else {
-			assert.Equal(t, fmt.Errorf(testTable.expectedError), err, testTable.testName)
-		}
+		assert.Equal(t, *expectedNormalizedURL, normalizeURL(rawURL), testTable.testName)
 	}
 }
 


### PR DESCRIPTION
With the current submission system, it's common for people to provide the tag/release URL rather than the repository
URL. I think it likely the same sort of thing will occur with the new system. Previously, a very naive check was done
for the path component of the URL to have two levels. It turns out that the Gitlab repository URLs have more levels than
that. The superior approach is to use `git ls-remote` to verify that the URL is a Git repository.