### PR TITLE
Update link to Library Manager registry repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Check Prettier Formatting status](https://github.com/arduino/library-manager-submission-parser/actions/workflows/check-prettier-formatting.yml/badge.svg)](https://github.com/arduino/library-manager-submission-parser/actions/workflows/check-prettier-formatting.yml)
 [![Spell Check status](https://github.com/arduino/library-manager-submission-parser/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino/library-manager-submission-parser/actions/workflows/spell-check.yml)
 
-This is the tool used to parse submissions to [the Arduino Library Manager registry](https://github.com/arduino/library-manager-registry).
+This is the tool used to parse submissions to [the Arduino Library Manager registry](https://github.com/arduino/library-registry).
 
 ## Security
 


### PR DESCRIPTION
The name of that repository has changed so the link must be updated accordingly.