### PR TITLE
Add list of indexer logs URLs to output

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -170,6 +170,21 @@ func Test_normalizeURL(t *testing.T) {
 	}
 }
 
+func Test_indexerLogsURL(t *testing.T) {
+	testTables := []struct {
+		testName               string
+		normalizedURL          string
+		expectedIndexerLogsURL string
+	}{
+		{"GitHub", "https://github.com/foo/bar.git", "http://downloads.arduino.cc/libraries/logs/github.com/foo/bar/"},
+		{"GitLab", "https://gitlab.com/yesbotics/libs/arduino/voltmeter.git", "http://downloads.arduino.cc/libraries/logs/gitlab.com/yesbotics/libs/arduino/voltmeter/"},
+	}
+
+	for _, testTable := range testTables {
+		assert.Equal(t, testTable.expectedIndexerLogsURL, indexerLogsURL(testTable.normalizedURL), testTable.testName)
+	}
+}
+
 func Test_uRLIsUnder(t *testing.T) {
 	testTables := []struct {
 		testName         string


### PR DESCRIPTION
The Library Manager indexer logs for each library are available via a public URL. This can be a useful tool for library
maintainers to track and troubleshoot the indexing of their releases.