### PR TITLE
Add git.antares.id to list of supported Git hosts

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 // Git hosts that are supported for library repositories.
 var supportedHosts []string = []string{
 	"bitbucket.org",
+	"git.antares.id",
 	"github.com",
 	"gitlab.com",
 }


### PR DESCRIPTION
Reference: https://github.com/bcmi-labs/libraries-repository-engine/commit/aba6510ed3d7a60e375ae991c54cff94cd4425a3