### PR TITLE
Prevent linkification of example URL in warning message

### DIFF
--- a/main.go
+++ b/main.go
@@ -243,7 +243,7 @@ func populateSubmission(submissionURL string, listPath *paths.Path) (submissionT
 	err = exec.Command("git", "ls-remote", normalizedURLObject.String()).Run()
 	if err != nil {
 		if _, ok := err.(*exec.ExitError); ok {
-			submission.Error = "Submission URL is not a Git clone URL (e.g., https://github.com/arduino-libraries/Servo)."
+			submission.Error = "Submission URL is not a Git clone URL (e.g., `https://github.com/arduino-libraries/Servo`)."
 			return submission, ""
 		}
 


### PR DESCRIPTION
When the submission is not a valid Git clone URL (e.g., they submitted the URL to a release page), a warning message is displayed:

>Submission URL is not a Git clone URL (e.g., https://github.com/arduino-libraries/Servo).

GitHub automatically linkifies the URL in the message when it is presented as a comment in the PR thread. I feel this linkification makes it less clear that the URL itself is intended to be the example. Wrapping it in backticks prevents the linkification.

Demo:
- before: https://github.com/per1234/library-registry/pull/24#issuecomment-827197838
- after: https://github.com/per1234/library-registry/pull/28#issuecomment-828126762