### PR TITLE
Update link shown when submission is on a supported Git host

### DIFF
--- a/main.go
+++ b/main.go
@@ -235,7 +235,7 @@ func populateSubmission(submissionURL string, listPath *paths.Path) (submissionT
 
 	// Check if URL is from a supported Git host.
 	if !uRLIsUnder(normalizedURLObject, supportedHosts) {
-		submission.Error = normalizedURLObject.Host + " is not currently supported as a Git hosting website for Library Manager.%0ASee: https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ#how-can-i-add-my-library-to-library-manager"
+		submission.Error = normalizedURLObject.Host + " is not currently supported as a Git hosting website for Library Manager.%0ASee: https://github.com/arduino/library-registry/blob/main/FAQ.md#what-are-the-requirements-for-a-library-to-be-added-to-library-manager"
 		return submission, ""
 	}
 


### PR DESCRIPTION
When the submission URL is not from on one of the Git hosts currently supported by the indexer, an error message is
displayed which provides a link to the section of the Library Manager URL that lists the submission requirements, along
with an explanation that addition of new major hosts can be considered on request.

That link points to the Library Manager FAQ hosted in the arduino/Arduino repository's wiki. That content has since been
migrated to the new repository, and will eventually be replaced by a link to the new location once it is public. So it's
best to point the URL directly to the new location for this information.

Due to an organization of the FAQ content, the most relevant content is now under a different heading, thus the anchor ID
change.