### PR TITLE
Handle root submission URLs

### DIFF
--- a/main.go
+++ b/main.go
@@ -355,7 +355,10 @@ func populateSubmission(submissionURL string, listPath *paths.Path) (submissionT
 // normalizeURL converts the URL into the standardized format used in the index.
 func normalizeURL(rawURL *url.URL) url.URL {
 	normalizedPath := strings.TrimRight(rawURL.Path, "/")
-	if !strings.HasSuffix(normalizedPath, ".git") {
+	if normalizedPath == "" {
+		// It doesn't make sense to add the extension to root URLs
+		normalizedPath = "/"
+	} else if !strings.HasSuffix(normalizedPath, ".git") {
 		normalizedPath += ".git"
 	}
 
@@ -392,11 +395,15 @@ func uRLIsUnder(childURL url.URL, parentCandidates []string) bool {
 			panic(err)
 		}
 
-		isUnderPath, err := paths.New(childURL.Path).IsInsideDir(paths.New(parentCandidateURL.Path))
+		childURLPath := paths.New(childURL.Path)
+		candidateURLPath := paths.New(parentCandidateURL.Path)
+
+		isUnderPath, err := childURLPath.IsInsideDir(candidateURLPath)
 		if err != nil {
 			panic(err)
 		}
-		if (childURL.Host == parentCandidateURL.Host) && isUnderPath {
+
+		if (childURL.Host == parentCandidateURL.Host) && (childURLPath.EqualsTo(candidateURLPath) || isUnderPath) {
 			return true
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -158,6 +158,8 @@ func Test_normalizeURL(t *testing.T) {
 		{".git suffix", "https://github.com/foo/bar.git", "https://github.com/foo/bar.git"},
 		{"http://", "http://github.com/foo/bar", "https://github.com/foo/bar.git"},
 		{"git://", "git://github.com/foo/bar", "https://github.com/foo/bar.git"},
+		{"Root URL", "https://github.com", "https://github.com/"},
+		{"Root URL with trailing slash", "https://github.com/", "https://github.com/"},
 	}
 
 	for _, testTable := range testTables {
@@ -196,6 +198,8 @@ func Test_uRLIsUnder(t *testing.T) {
 		{"Mismatch, root path", "https://github.com/foo/bar", []string{"example.com", "example.org"}, assert.False},
 		{"Match, subfolder", "https://github.com/foo/bar", []string{"example.com/foo", "github.com/foo"}, assert.True},
 		{"Mismatch, subfolder", "https://github.com/foo/bar", []string{"example.com/foo", "github.org/bar"}, assert.False},
+		{"Match, root child URL", "https://github.com/", []string{"example.com", "github.com"}, assert.True},
+		{"Mismatch, root child URL", "https://github.com/", []string{"example.com", "github.org"}, assert.False},
 	}
 
 	for _, testTable := range testTables {


### PR DESCRIPTION
Previously, a submission URL with a root path resulted in a panic:
```
panic: Rel: can't make .git relative to /
```
These URLs won't represent a valid submission, but panics should only occur when the error should not occur under any normal circumstances. By avoiding the panic, the process will fail with the helpful error either that the URL is not under a supported Git host (e.g., `https://mycoollibrary.com` as submission), or that it is not a valid Git clone URL (e.g., `https://github.com` as submission).