### PR TITLE
Check for duplicates within the submission itself

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,6 +129,15 @@ func main() {
 		indexerLogsURLs = append(indexerLogsURLs, indexerLogsURL(submission.NormalizedURL))
 	}
 
+	// Check for duplicates within the submission itself.
+	submissionURLMap := make(map[string]bool)
+	for submissionIndex, submission := range req.Submissions {
+		submissionURLMap[submission.NormalizedURL] = true
+		if len(submissionURLMap) <= submissionIndex {
+			req.Submissions[submissionIndex].Error = "Submission contains duplicate URLs."
+		}
+	}
+
 	// Assemble the index entry for the submissions.
 	req.IndexEntry = strings.Join(indexEntries, "%0A")
 


### PR DESCRIPTION
A check for duplication between the submission and the libraries already on the list was already done. However, it is
possible that submitters will add the same library twice within a single submission. This was not previously checked for.
In addition to causing confusion at a later time for people working directly with the list, it's also possible that
allowing duplicates into the list could have harmful implications for the indexer or for Library Manager itself.

So it's safest to make a check for duplicates within the submission and return a helpful error message, requiring the
submission to contain only unique libraries before accepting it.

---
### Demos
- Before this change: https://github.com/per1234/library-registry/pull/39#issuecomment-829328027
  (note submission containing duplicate URLs was accepted)
- After this change: https://github.com/per1234/library-registry/pull/41#issuecomment-829338299
  (note submission was rejected until the duplicate URL it contained was removed)