### PR TITLE
Output appropriate `arduino-lint --library-manager` setting

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,10 +60,11 @@ var recommendedOrganizations []string = []string{
 
 // request is the type of the request data.
 type request struct {
-	Type            string           `json:"type"`            // Request type.
-	Submissions     []submissionType `json:"submissions"`     // Data for submitted libraries.
-	IndexEntry      string           `json:"indexEntry"`      // Entry that will be made to the Library Manager index source file when the submission is accepted.
-	IndexerLogsURLs string           `json:"indexerLogsURLs"` // List of URLs where the logs from the Library Manager indexer for each submission are available for view.
+	Type                             string           `json:"type"`                             // Request type.
+	ArduinoLintLibraryManagerSetting string           `json:"arduinoLintLibraryManagerSetting"` // Argument to pass to Arduino Lint's --library-manager flag.
+	Submissions                      []submissionType `json:"submissions"`                      // Data for submitted libraries.
+	IndexEntry                       string           `json:"indexEntry"`                       // Entry that will be made to the Library Manager index source file when the submission is accepted.
+	IndexerLogsURLs                  string           `json:"indexerLogsURLs"`                  // List of URLs where the logs from the Library Manager indexer for each submission are available for view.
 }
 
 // submissionType is the type of the data for each individual library submitted in the request.
@@ -116,7 +117,7 @@ func main() {
 	}
 	var req request
 	var submissionURLs []string
-	req.Type, submissionURLs = parseDiff(rawDiff, *listNameArgument)
+	req.Type, req.ArduinoLintLibraryManagerSetting, submissionURLs = parseDiff(rawDiff, *listNameArgument)
 
 	// Process the submissions.
 	var indexEntries []string
@@ -155,8 +156,8 @@ func errorExit(message string) {
 	os.Exit(1)
 }
 
-// parseDiff parses the request diff and returns the request type and list of submission URLs.
-func parseDiff(rawDiff []byte, listName string) (string, []string) {
+// parseDiff parses the request diff and returns the request type, `arduino-lint --library-manager` setting, and list of submission URLs.
+func parseDiff(rawDiff []byte, listName string) (string, string, []string) {
 	var submissionURLs []string
 
 	diffs, err := diff.ParseMultiFileDiff(rawDiff)
@@ -166,7 +167,7 @@ func parseDiff(rawDiff []byte, listName string) (string, []string) {
 
 	if (len(diffs) != 1) || (diffs[0].OrigName[2:] != listName) || (diffs[0].OrigName[2:] != diffs[0].NewName[2:]) { // Git diffs have a a/ or b/ prefix on file names.
 		// This is not a Library Manager submission.
-		return "other", nil
+		return "other", "", nil
 	}
 
 	var addedCount int
@@ -193,15 +194,19 @@ func parseDiff(rawDiff []byte, listName string) (string, []string) {
 	}
 
 	var requestType string
+	var arduinoLintLibraryManagerSetting string
 	if addedCount > 0 && deletedCount == 0 {
 		requestType = "submission"
+		arduinoLintLibraryManagerSetting = "submit"
 	} else if addedCount == 0 && deletedCount > 0 {
 		requestType = "removal"
+		arduinoLintLibraryManagerSetting = ""
 	} else {
 		requestType = "modification"
+		arduinoLintLibraryManagerSetting = "update"
 	}
 
-	return requestType, submissionURLs
+	return requestType, arduinoLintLibraryManagerSetting, submissionURLs
 }
 
 // populateSubmission does the checks on the submission that aren't provided by Arduino Lint and gathers the necessary data on it.

--- a/main_test.go
+++ b/main_test.go
@@ -37,8 +37,9 @@ index cff484d..e14c179 100644
 +https://github.com/foo/bar
 `)
 
-	requestType, submissionURLs := parseDiff(diff, "repositories.txt")
+	requestType, arduinoLintLibraryManagerSetting, submissionURLs := parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "other", requestType, testName)
+	assert.Equal(t, "", arduinoLintLibraryManagerSetting, testName)
 	assert.Nil(t, submissionURLs, testName)
 
 	testName = "Not list"
@@ -52,8 +53,9 @@ index d4edde0..807b76d 100644
 +hello
 `)
 
-	requestType, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "other", requestType, testName)
+	assert.Equal(t, "", arduinoLintLibraryManagerSetting, testName)
 	assert.Nil(t, submissionURLs, testName)
 
 	testName = "List filename change"
@@ -69,8 +71,9 @@ index cff484d..e14c179 100644
 +https://github.com/foo/bar
 `)
 
-	requestType, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "other", requestType, testName)
+	assert.Equal(t, "", arduinoLintLibraryManagerSetting, testName)
 	assert.Nil(t, submissionURLs, testName)
 
 	testName = "Submission"
@@ -84,8 +87,9 @@ index cff484d..9f67763 100644
 +https://github.com/foo/baz
 `)
 
-	requestType, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "submission", requestType, testName)
+	assert.Equal(t, "submit", arduinoLintLibraryManagerSetting, testName)
 	assert.ElementsMatch(t, submissionURLs, []string{"https://github.com/foo/bar", "https://github.com/foo/baz"}, testName)
 
 	testName = "Submission w/ no newline at end of file"
@@ -99,8 +103,9 @@ index cff484d..1b0b80b 100644
 \ No newline at end of file
 `)
 
-	requestType, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "submission", requestType, testName)
+	assert.Equal(t, "submit", arduinoLintLibraryManagerSetting, testName)
 	assert.ElementsMatch(t, submissionURLs, []string{"https://github.com/foo/bar"}, testName)
 
 	testName = "Submission w/ blank line"
@@ -114,8 +119,9 @@ index cff484d..1b0b80b 100644
 \ No newline at end of file
 `)
 
-	requestType, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "submission", requestType, testName)
+	assert.Equal(t, "submit", arduinoLintLibraryManagerSetting, testName)
 	assert.ElementsMatch(t, submissionURLs, []string{"https://github.com/foo/bar"}, testName)
 
 	testName = "Removal"
@@ -128,8 +134,9 @@ index cff484d..38e11d8 100644
 -https://github.com/arduino-libraries/Ethernet
 `)
 
-	requestType, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "removal", requestType, testName)
+	assert.Equal(t, "", arduinoLintLibraryManagerSetting, testName)
 	assert.Nil(t, submissionURLs, testName)
 
 	testName = "Modification"
@@ -143,8 +150,9 @@ index cff484d..8b401a1 100644
 +https://github.com/foo/bar
 `)
 
-	requestType, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "modification", requestType, testName)
+	assert.Equal(t, "update", arduinoLintLibraryManagerSetting, testName)
 	assert.Equal(t, submissionURLs, []string{"https://github.com/foo/bar"}, testName)
 }
 


### PR DESCRIPTION
When a submission URL is modified, it must also be checked. In this case, the `arduino/arduino-lint-action`'s
`library-manager` input setting must be "update" instead of "submit", since the library is already in the index.

Since, manual testing of GitHub Actions workflows is not well supported, it's best to keep as much of the logic as
possible in the Go code of the parser. For this reason, the parser should determine the appropriate `library-manager`
setting and pass that to the workflow.

Demo: https://github.com/per1234/library-registry/pull/44