### PR TITLE
Update license headers to reflect license type change

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,17 @@
-// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+// Copyright 2021 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3.
-// The terms of this license can be found at:
-// https://www.gnu.org/licenses/gpl-3.0.en.html
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 // You can be released from the requirements of the above licenses by purchasing
 // a commercial license. Buying such a license is mandatory if you want to

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,17 @@
-// Copyright 2020 ARDUINO SA (http://www.arduino.cc/)
+// Copyright 2021 ARDUINO SA (http://www.arduino.cc/)
 //
-// This software is released under the GNU General Public License version 3.
-// The terms of this license can be found at:
-// https://www.gnu.org/licenses/gpl-3.0.en.html
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 // You can be released from the requirements of the above licenses by purchasing
 // a commercial license. Buying such a license is mandatory if you want to


### PR DESCRIPTION
The project's license was changed from GPL-3.0 to AGPL-3.0 (https://github.com/arduino/library-registry-submission-parser/pull/2#issuecomment-810092933) but the license headers were not changed accordingly. The new
headers are based on the instructions in the AGPLv3 license text and the previous header text.