### PR TITLE
Use archived repository for "Partner" library type test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ parser.exe
 
 # Test artifacts
 coverage_unit.txt
+__pycache__/
 
 # IDEs
 .idea/

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -155,17 +155,17 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
             "submission",
             [
                 {
-                    "submissionURL": "https://github.com/Azure/azure-iot-arduino-utility",
-                    "normalizedURL": "https://github.com/Azure/azure-iot-arduino-utility.git",
-                    "repositoryName": "azure-iot-arduino-utility",
-                    "name": "AzureIoTUtility",
+                    "submissionURL": "https://github.com/ms-iot/virtual-shields-arduino",
+                    "normalizedURL": "https://github.com/ms-iot/virtual-shields-arduino.git",
+                    "repositoryName": "virtual-shields-arduino",
+                    "name": "Windows Virtual Shields for Arduino",
                     "official": False,
-                    "tag": "v1.5.0",
+                    "tag": "v1.2.0",
                     "error": "",
                 }
             ],
-            "https://github.com/Azure/azure-iot-arduino-utility.git|Partner|AzureIoTUtility",
-            "http://downloads.arduino.cc/libraries/logs/github.com/Azure/azure-iot-arduino-utility/",
+            "https://github.com/ms-iot/virtual-shields-arduino.git|Partner|Windows Virtual Shields for Arduino",
+            "http://downloads.arduino.cc/libraries/logs/github.com/ms-iot/virtual-shields-arduino/",
         ),
         (
             "type-recommended",

--- a/test/testdata/type-partner/diff.txt
+++ b/test/testdata/type-partner/diff.txt
@@ -3,6 +3,6 @@ index c080a7a..dcba162 100644
 --- a/repositories.txt
 +++ b/repositories.txt
 @@ -1,2 +1,3 @@
-+https://github.com/Azure/azure-iot-arduino-utility
++https://github.com/ms-iot/virtual-shields-arduino
  https://github.com/arduino-libraries/Servo
  https://github.com/arduino-libraries/Stepper


### PR DESCRIPTION
The repository previously used as a test case for the "Partner" library type integration test has become active again,
resulting in spurious test breakage. It has been replaced by another test case which appears much more likely to stay
archived.