### PR TITLE
Use new arduino/setup-task action name in CI/CD workflows

### DIFF
--- a/.github/workflows/check-go.yml
+++ b/.github/workflows/check-go.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/check-prettier-formatting.yml
+++ b/.github/workflows/check-prettier-formatting.yml
@@ -215,7 +215,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/check-python.yml
+++ b/.github/workflows/check-python.yml
@@ -40,7 +40,7 @@ jobs:
         run: pip install poetry
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -64,7 +64,7 @@ jobs:
         run: pip install poetry
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -27,7 +27,7 @@ jobs:
         run: pip install poetry
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -33,7 +33,7 @@ jobs:
           go-version: "1.14"
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -47,7 +47,7 @@ jobs:
         run: pip install poetry
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x


### PR DESCRIPTION
The GitHub Actions action for installing [Task](https://taskfile.dev/#/) has graduated from its original home in [the experimental `arduino/action`repository](https://github.com/arduino/actions) with a move to a dedicated permanent repository at [`arduino/setup-task`](https://github.com/arduino/setup-task).

A [1.0.0 release](https://github.com/arduino/setup-task/releases/tag/v1.0.0) has been made and [a `v1` ref](https://github.com/arduino/setup-task/tree/v1) that will track all releases in the major version 1 series. Use of the action's major version ref will cause the workflow to benefit from ongoing development to the action at each [patch or minor release](https://semver.org/) up until such time as a new major release is made. At this time the user will be given the opportunity to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before manually updating the major ref in the workflows (e.g., `uses: arduino/setup-task@v2`).