### PR TITLE
Configure Dependabot for Go and Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,17 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+  # Go dependencies
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"
+  # Python dependencies
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"


### PR DESCRIPTION
Dependabot is already in use to maintain the dependencies of the project's GitHub Actions workflows. It will be helpful
to do the same with the Go dependencies.

With the introduction of Python-based integration tests, the Python dependencies of the project became more significant.
So we might as well use Dependabot for them too!

Reference:
https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#about-the-dependabotyml-file