### PR TITLE
Report removal of final newline

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -46,8 +46,9 @@ index cff484d..e14c179 100644
 +https://github.com/foo/bar
 `)
 
-	requestType, arduinoLintLibraryManagerSetting, submissionURLs := parseDiff(diff, "repositories.txt")
+	requestType, requestError, arduinoLintLibraryManagerSetting, submissionURLs := parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "other", requestType, testName)
+	assert.Equal(t, "", requestError, testName)
 	assert.Equal(t, "", arduinoLintLibraryManagerSetting, testName)
 	assert.Nil(t, submissionURLs, testName)
 
@@ -62,8 +63,9 @@ index d4edde0..807b76d 100644
 +hello
 `)
 
-	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, requestError, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "other", requestType, testName)
+	assert.Equal(t, "", requestError, testName)
 	assert.Equal(t, "", arduinoLintLibraryManagerSetting, testName)
 	assert.Nil(t, submissionURLs, testName)
 
@@ -80,8 +82,9 @@ index cff484d..e14c179 100644
 +https://github.com/foo/bar
 `)
 
-	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, requestError, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "other", requestType, testName)
+	assert.Equal(t, "", requestError, testName)
 	assert.Equal(t, "", arduinoLintLibraryManagerSetting, testName)
 	assert.Nil(t, submissionURLs, testName)
 
@@ -96,8 +99,9 @@ index cff484d..9f67763 100644
 +https://github.com/foo/baz
 `)
 
-	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, requestError, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "submission", requestType, testName)
+	assert.Equal(t, "", requestError, testName)
 	assert.Equal(t, "submit", arduinoLintLibraryManagerSetting, testName)
 	assert.ElementsMatch(t, submissionURLs, []string{"https://github.com/foo/bar", "https://github.com/foo/baz"}, testName)
 
@@ -112,10 +116,11 @@ index cff484d..1b0b80b 100644
 \ No newline at end of file
 `)
 
-	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
-	assert.Equal(t, "submission", requestType, testName)
-	assert.Equal(t, "submit", arduinoLintLibraryManagerSetting, testName)
-	assert.ElementsMatch(t, submissionURLs, []string{"https://github.com/foo/bar"}, testName)
+	requestType, requestError, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
+	assert.Equal(t, "invalid", requestType, testName)
+	assert.Equal(t, "Pull request removes newline from the end of a file.%0APlease add a blank line to the end of the file.", requestError, testName)
+	assert.Equal(t, "", arduinoLintLibraryManagerSetting, testName)
+	assert.Nil(t, submissionURLs, testName)
 
 	testName = "Submission w/ blank line"
 	diff = []byte(`
@@ -125,11 +130,12 @@ index cff484d..1b0b80b 100644
 +++ b/repositories.txt
 @@ -3391,0 +3392 @@ https://github.com/lbernstone/plotutils
 +https://github.com/foo/bar
-\ No newline at end of file
++
 `)
 
-	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, requestError, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "submission", requestType, testName)
+	assert.Equal(t, "", requestError, testName)
 	assert.Equal(t, "submit", arduinoLintLibraryManagerSetting, testName)
 	assert.ElementsMatch(t, submissionURLs, []string{"https://github.com/foo/bar"}, testName)
 
@@ -143,8 +149,9 @@ index cff484d..38e11d8 100644
 -https://github.com/arduino-libraries/Ethernet
 `)
 
-	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, requestError, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "removal", requestType, testName)
+	assert.Equal(t, "", requestError, testName)
 	assert.Equal(t, "", arduinoLintLibraryManagerSetting, testName)
 	assert.Nil(t, submissionURLs, testName)
 
@@ -159,8 +166,9 @@ index cff484d..8b401a1 100644
 +https://github.com/foo/bar
 `)
 
-	requestType, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
+	requestType, requestError, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
 	assert.Equal(t, "modification", requestType, testName)
+	assert.Equal(t, "", requestError, testName)
 	assert.Equal(t, "update", arduinoLintLibraryManagerSetting, testName)
 	assert.Equal(t, submissionURLs, []string{"https://github.com/foo/bar"}, testName)
 }

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -21,16 +21,30 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
 
 
 @pytest.mark.parametrize(
-    "repopath_folder_name, expected_type, expected_submissions, expected_indexentry, expected_indexerlogsurls",
+    "repopath_folder_name,"
+    "expected_type,"
+    "expected_error,"
+    "expected_submissions,"
+    "expected_indexentry,"
+    "expected_indexerlogsurls",
     [
-        ("list-deleted-diff", "other", None, "", ""),
-        ("multi-file-diff", "other", None, "", ""),
-        ("non-list-diff", "other", None, "", ""),
-        ("list-rename-diff", "other", None, "", ""),
-        ("removal", "removal", None, "", ""),
+        ("list-deleted-diff", "other", "", None, "", ""),
+        ("multi-file-diff", "other", "", None, "", ""),
+        ("non-list-diff", "other", "", None, "", ""),
+        ("list-rename-diff", "other", "", None, "", ""),
+        (
+            "no-final-newline-diff",
+            "invalid",
+            "Pull request removes newline from the end of a file.%0APlease add a blank line to the end of the file.",
+            None,
+            "",
+            "",
+        ),
+        ("removal", "removal", "", None, "", ""),
         (
             "modification",
             "modification",
+            "",
             [
                 {
                     "submissionURL": "https://github.com/arduino-libraries/ArduinoCloudThing",
@@ -48,6 +62,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "url-error",
             "submission",
+            "",
             [
                 {
                     "submissionURL": "foo",
@@ -65,6 +80,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "url-404",
             "submission",
+            "",
             [
                 {
                     "submissionURL": "http://httpstat.us/404",
@@ -82,6 +98,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "not-supported-git-host",
             "submission",
+            "",
             [
                 {
                     "submissionURL": "https://example.com",
@@ -101,6 +118,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "not-git-clone-url",
             "submission",
+            "",
             [
                 {
                     "submissionURL": "https://github.com/arduino-libraries/ArduinoCloudThing/releases",
@@ -119,6 +137,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "already-in-library-manager",
             "submission",
+            "",
             [
                 {
                     "submissionURL": "https://github.com/arduino-libraries/Servo",
@@ -136,6 +155,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "type-arduino",
             "submission",
+            "",
             [
                 {
                     "submissionURL": "https://github.com/arduino-libraries/ArduinoCloudThing",
@@ -153,6 +173,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "type-partner",
             "submission",
+            "",
             [
                 {
                     "submissionURL": "https://github.com/ms-iot/virtual-shields-arduino",
@@ -170,6 +191,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "type-recommended",
             "submission",
+            "",
             [
                 {
                     "submissionURL": "https://github.com/adafruit/Adafruit_TinyFlash",
@@ -187,6 +209,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "type-contributed",
             "submission",
+            "",
             [
                 {
                     "submissionURL": "https://github.com/sparkfun/SparkFun_Ublox_Arduino_Library",
@@ -205,6 +228,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "no-tags",
             "submission",
+            "",
             [
                 {
                     "submissionURL": "https://github.com/arduino/cloud-examples",
@@ -224,6 +248,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "no-library-properties",
             "submission",
+            "",
             [
                 {
                     "submissionURL": "https://github.com/arduino-libraries/WiFiLink-Firmware",
@@ -242,6 +267,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "duplicates-in-submission",
             "submission",
+            "",
             [
                 {
                     "submissionURL": "https://github.com/arduino-libraries/ArduinoCloudThing",
@@ -273,6 +299,7 @@ def test_request(
     run_command,
     repopath_folder_name,
     expected_type,
+    expected_error,
     expected_submissions,
     expected_indexentry,
     expected_indexerlogsurls,
@@ -286,6 +313,7 @@ def test_request(
 
     request = json.loads(result.stdout)
     assert request["type"] == expected_type
+    assert request["error"] == expected_error
     assert request["submissions"] == expected_submissions
     assert request["indexEntry"] == expected_indexentry
     assert request["submissions"] == expected_submissions

--- a/test/testdata/no-final-newline-diff/diff.txt
+++ b/test/testdata/no-final-newline-diff/diff.txt
@@ -1,0 +1,9 @@
+diff --git a/repositories.txt b/repositories.txt
+index c080a7a..dcba162 100644
+--- a/repositories.txt
++++ b/repositories.txt
+@@ -1,2 +1,3 @@
+ https://github.com/arduino-libraries/Servo
+ https://github.com/arduino-libraries/Stepper
++https://github.com/arduino-libraries/ArduinoCloudThing
+\ No newline at end of file

--- a/test/testdata/no-final-newline-diff/repositories.txt
+++ b/test/testdata/no-final-newline-diff/repositories.txt
@@ -1,0 +1,2 @@
+https://github.com/arduino-libraries/Servo
+https://github.com/arduino-libraries/Stepper


### PR DESCRIPTION
If a file does not end in a newline, then every line added to the end of the file results in a diff to the previous final
line.

An example using `\n` to symbolize end of line characters:
```
https://github.com/arduino-libraries/Servo\n
https://github.com/arduino-libraries/Stepper
```
When another line is added at the end:
```
https://github.com/arduino-libraries/Servo\n
https://github.com/arduino-libraries/Stepper\n
https://github.com/arduino-libraries/FooBar
```
you can see there is necessarily a diff on line 2 even though the editor did not touch that line.

For this reason, it is best practices to always retain a newline at the end of files.

In addition to it being common practice, the GitHub web editor automatically adds this newline. Between this and my
expectation that people would either add URLs to the top of the list or in alphabetical order, leaving the distant end of
the file alone, I was hoping that this would not be a common problem with the library submission system, but this is
simply not a realistic expectation.

What I hadn’t considered is that the person to suffer for this formatting is the next to add a URL to the end of the
file. Because of this “ghost diff”, the submission system sees this PR as a modification to an existing item on the list
rather than an addition.

I think this will be best handled by detecting and dealing with the problem at its introduction, rather than attempting
to make the system resilient to a missing final newline.

---
The associated changes to the arduino/library-registry repository's "Manage PRs" workflow: https://github.com/per1234/library-registry/commit/f8385ae72be5f2887d786185063262ff0fb6f2df
Demonstration of the updated parser in action: https://github.com/per1234/library-registry/pull/8#issuecomment-886059515