### PR TITLE
Update to Go 1.16

### DIFF
--- a/.github/workflows/check-go.yml
+++ b/.github/workflows/check-go.yml
@@ -1,5 +1,9 @@
 name: Check Go
 
+env:
+  # See: https://github.com/actions/setup-go/tree/v2#readme
+  GO_VERSION: "1.16"
+
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
   push:
@@ -30,6 +34,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
       - name: Install Taskfile
         uses: arduino/setup-task@v1
         with:
@@ -46,6 +55,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
       - name: Install Taskfile
         uses: arduino/setup-task@v1
         with:
@@ -61,6 +75,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Taskfile
         uses: arduino/setup-task@v1

--- a/.github/workflows/check-go.yml
+++ b/.github/workflows/check-go.yml
@@ -66,8 +66,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
+      - name: Install golint
+        run: go install golang.org/x/lint/golint@latest
+
       - name: Check style
-        run: task go:lint
+        run: task --silent go:lint
 
   check-formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Create Release
 
+env:
+  # See: https://github.com/actions/setup-go/tree/v2#readme
+  GO_VERSION: "1.14"
+
 on:
   push:
     tags:
@@ -29,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.14"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Build project
         run: task go:build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Create Release
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.14"
+  GO_VERSION: "1.16"
 
 on:
   push:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -2,7 +2,7 @@ name: Test Go
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.14"
+  GO_VERSION: "1.16"
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -1,5 +1,9 @@
 name: Test Go
 
+env:
+  # See: https://github.com/actions/setup-go/tree/v2#readme
+  GO_VERSION: "1.14"
+
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
   push:
@@ -30,7 +34,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.14"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Taskfile
         uses: arduino/setup-task@v1

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,5 +1,11 @@
 name: Test Integration
 
+env:
+  # See: https://github.com/actions/setup-go/tree/v2#readme
+  GO_VERSION: "1.14"
+  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  PYTHON_VERSION: "3.9"
+
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
   push:
@@ -36,12 +42,12 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.14"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -2,7 +2,7 @@ name: Test Integration
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.14"
+  GO_VERSION: "1.16"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
   PYTHON_VERSION: "3.9"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -49,10 +49,13 @@ tasks:
   go:lint:
     desc: Lint Go code
     cmds:
-      - go get golang.org/x/lint/golint
       - |
-        GOLINT_PATH="$(go list -f '{{"{{"}}.Target{{"}}"}}' golang.org/x/lint/golint || echo "false")"
-        "$GOLINT_PATH" \
+        if ! which golint &>/dev/null; then
+          echo "golint not installed or not in PATH. Please install: https://github.com/golang/lint#installation"
+          exit 1
+        fi
+      - |
+        golint \
           {{default "-min_confidence 0.8 -set_exit_status" .GO_LINT_FLAGS}} \
           {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/library-registry-submission-parser/parser
 
-go 1.14
+go 1.16
 
 require (
 	github.com/arduino/go-paths-helper v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -19,7 +19,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
1.16 is now the preferred Go version for all Arduino tooling projects.

The update from Go 1.14 to 1.16 broke the task that runs golint. The good news is that the new go install command
eliminates the need for the workaround of running the go get golang.org/x/lint/golint command from outside the project
path.

The bad news is the go list command used to get the path of the golint installation does not work in the "module-aware
mode" that is now the default. In the end, I gave up on making the task work as before. I think it's better to require
the user to install golint and put the installation in the system PATH, displaying a helpful message when this has not
been done.