### PR TITLE
Sync "Test Go" CI workflow with template

### DIFF
--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -8,15 +8,15 @@ env:
 on:
   push:
     paths:
-      - ".github/workflows/test-go-task.yml"
-      - "Taskfile.yml"
+      - ".github/workflows/test-go-task.ya?ml"
+      - "Taskfile.ya?ml"
       - "**.go"
       - "go.mod"
       - "go.sum"
   pull_request:
     paths:
-      - ".github/workflows/test-go-task.yml"
-      - "Taskfile.yml"
+      - ".github/workflows/test-go-task.ya?ml"
+      - "Taskfile.ya?ml"
       - "**.go"
       - "go.mod"
       - "go.sum"

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -1,3 +1,4 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/test-go-task.md
 name: Test Go
 
 env:

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Install Taskfile
+      - name: Install Task
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -8,14 +8,14 @@ env:
 on:
   push:
     paths:
-      - ".github/workflows/test-go.yml"
+      - ".github/workflows/test-go-task.yml"
       - "Taskfile.yml"
       - "**.go"
       - "go.mod"
       - "go.sum"
   pull_request:
     paths:
-      - ".github/workflows/test-go.yml"
+      - ".github/workflows/test-go-task.yml"
       - "Taskfile.yml"
       - "**.go"
       - "go.mod"

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -9,20 +9,20 @@ on:
   push:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
-      - "Taskfile.ya?ml"
-      - "**.go"
       - "codecov.ya?ml"
       - "go.mod"
       - "go.sum"
+      - "Taskfile.ya?ml"
+      - "**.go"
       - "**/testdata/**"
   pull_request:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
-      - "Taskfile.ya?ml"
-      - "**.go"
       - "codecov.ya?ml"
       - "go.mod"
       - "go.sum"
+      - "Taskfile.ya?ml"
+      - "**.go"
       - "**/testdata/**"
   workflow_dispatch:
   repository_dispatch:

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -11,6 +11,7 @@ on:
       - ".github/workflows/test-go-task.ya?ml"
       - "Taskfile.ya?ml"
       - "**.go"
+      - "codecov.ya?ml"
       - "go.mod"
       - "go.sum"
   pull_request:
@@ -18,6 +19,7 @@ on:
       - ".github/workflows/test-go-task.ya?ml"
       - "Taskfile.ya?ml"
       - "**.go"
+      - "codecov.ya?ml"
       - "go.mod"
       - "go.sum"
   workflow_dispatch:
@@ -44,3 +46,11 @@ jobs:
 
       - name: Run tests
         run: task go:test
+
+      - name: Send unit tests coverage to Codecov
+        if: matrix.operating-system == 'ubuntu-latest'
+        uses: codecov/codecov-action@v2
+        with:
+          file: ./coverage_unit.txt
+          flags: unit
+          fail_ci_if_error: true

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -14,6 +14,7 @@ on:
       - "codecov.ya?ml"
       - "go.mod"
       - "go.sum"
+      - "**/testdata/**"
   pull_request:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
@@ -22,6 +23,7 @@ on:
       - "codecov.ya?ml"
       - "go.mod"
       - "go.sum"
+      - "**/testdata/**"
   workflow_dispatch:
   repository_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Arduino Library Manager submission parser
 
 [![Test Go status](https://github.com/arduino/library-registry-submission-parser/actions/workflows/test-go-task.yml/badge.svg)](https://github.com/arduino/library-registry-submission-parser/actions/workflows/test-go-task.yml)
+[![Codecov](https://codecov.io/gh/arduino/library-registry-submission-parser/branch/main/graph/badge.svg)](https://codecov.io/gh/arduino/library-registry-submission-parser)
 [![Check Go status](https://github.com/arduino/library-registry-submission-parser/actions/workflows/check-go.yml/badge.svg)](https://github.com/arduino/library-registry-submission-parser/actions/workflows/check-go.yml)
 [![Check Python status](https://github.com/arduino/library-registry-submission-parser/actions/workflows/check-python-task.yml/badge.svg)](https://github.com/arduino/library-registry-submission-parser/actions/workflows/check-python-task.yml)
 [![Check Prettier Formatting status](https://github.com/arduino/library-registry-submission-parser/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/arduino/library-registry-submission-parser/actions/workflows/check-prettier-formatting-task.yml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arduino Library Manager submission parser
 
-[![Test Go status](https://github.com/arduino/library-registry-submission-parser/actions/workflows/test-go.yml/badge.svg)](https://github.com/arduino/library-registry-submission-parser/actions/workflows/test-go.yml)
+[![Test Go status](https://github.com/arduino/library-registry-submission-parser/actions/workflows/test-go-task.yml/badge.svg)](https://github.com/arduino/library-registry-submission-parser/actions/workflows/test-go-task.yml)
 [![Check Go status](https://github.com/arduino/library-registry-submission-parser/actions/workflows/check-go.yml/badge.svg)](https://github.com/arduino/library-registry-submission-parser/actions/workflows/check-go.yml)
 [![Check Python status](https://github.com/arduino/library-registry-submission-parser/actions/workflows/check-python-task.yml/badge.svg)](https://github.com/arduino/library-registry-submission-parser/actions/workflows/check-python-task.yml)
 [![Check Prettier Formatting status](https://github.com/arduino/library-registry-submission-parser/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/arduino/library-registry-submission-parser/actions/workflows/check-prettier-formatting-task.yml)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -28,6 +28,7 @@ tasks:
     cmds:
       - go build -v {{.GO_BUILD_FLAGS}}
 
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-task/Taskfile.yml
   go:test:
     desc: Run unit tests
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,7 +31,14 @@ tasks:
   go:test:
     desc: Run unit tests
     cmds:
-      - go test -v -short -run '{{default ".*" .GO_TEST_REGEX}}' {{default "-timeout 10m -coverpkg=./... -covermode=atomic" .GO_TEST_FLAGS}} -coverprofile=coverage_unit.txt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
+      - |
+        go test \
+          -v \
+          -short \
+          -run '{{default ".*" .GO_TEST_REGEX}}' \
+          {{default "-timeout 10m -coverpkg=./... -covermode=atomic" .GO_TEST_FLAGS}} \
+          -coverprofile=coverage_unit.txt \
+          {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   go:test-integration:
     desc: Run integration tests


### PR DESCRIPTION
We have assembled a collection of reusable GitHub Actions workflows:
https://github.com/arduino/tooling-project-assets
These workflows will be used in the repositories of all Arduino tooling projects.

Some minor improvements and standardizations have been made in the upstream "template" workflow, and those are introduced to this repository via this pull request.