### PR TITLE
Assign "other" request type for newline-only diffs

### DIFF
--- a/main.go
+++ b/main.go
@@ -223,7 +223,9 @@ func parseDiff(rawDiff []byte, listName string) (string, string, string, []strin
 
 	var requestType string
 	var arduinoLintLibraryManagerSetting string
-	if addedCount > 0 && deletedCount == 0 {
+	if addedCount == 0 && deletedCount == 0 {
+		requestType = "other"
+	} else if addedCount > 0 && deletedCount == 0 {
 		requestType = "submission"
 		arduinoLintLibraryManagerSetting = "submit"
 	} else if addedCount == 0 && deletedCount > 0 {

--- a/main_test.go
+++ b/main_test.go
@@ -171,6 +171,26 @@ index cff484d..8b401a1 100644
 	assert.Equal(t, "", requestError, testName)
 	assert.Equal(t, "update", arduinoLintLibraryManagerSetting, testName)
 	assert.Equal(t, []string{"https://github.com/foo/bar"}, submissionURLs, testName)
+
+	testName = "Newline-only"
+	diff = []byte(`
+diff --git a/repositories.txt b/repositories.txt
+index d9a6136..ca902d9 100644
+--- a/repositories.txt
++++ b/repositories.txt
+@@ -1,4 +1,4 @@
+	https://github.com/firmata/arduino
+-
+	https://github.com/arduino-libraries/Ethernet
+	https://github.com/lbernstone/plotutils
++
+`)
+
+	requestType, requestError, arduinoLintLibraryManagerSetting, submissionURLs = parseDiff(diff, "repositories.txt")
+	assert.Equal(t, "other", requestType, testName)
+	assert.Equal(t, "", requestError, testName)
+	assert.Equal(t, "", arduinoLintLibraryManagerSetting, testName)
+	assert.Nil(t, submissionURLs, testName)
 }
 
 func Test_normalizeURL(t *testing.T) {


### PR DESCRIPTION
In order to make the system as lenient as possible in regards to submission format, newline changes to the list are ignored (with the exception of final newline removal). For this reason, a PR consisting solely of changes to the newlines in the list results in a null list of URLs, as would be expected.

The problem was that these PRs were assigned a "modification" type. A workflow job matrix is used to check the list of URLs generated from a "modification" request "update" mode to see whether they are still compliant with the requirements in order to triage modification requests before the registry maintainer does the final manual review of the PR.

GitHub Actions does not allow zero length job matrices, and anyway this sort of PR does not match with the meaning we have assigned the "modification" type. The "other" type is most appropriate for this type of PR. "other" type requests are also manually reviewed, but without the automated triage which is not relevant to these requests.