### PR TITLE
Add maintenance automation features from GitHub issue templates system

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,8 @@
+---
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/minimal/bug-report.md
+name: Bug report
+about: Report a problem with the code or documentation in this repository.
+title: ""
+labels: "type: imperfection"
+assignees: ""
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# Source:
+# https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/template-choosers/general/config.yml
+# See:
+# https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+
+blank_issues_enabled: false
+contact_links:
+  - name: Learn about the Arduino Library Manager registry
+    url: https://github.com/arduino/library-registry#readme
+    about: arduino/library-registry-submission-parser is a component of the Arduino Library Manager registry infrastructure.
+  - name: Support request
+    url: https://forum.arduino.cc/
+    about: We can help you out on the Arduino Forum!
+  - name: Discuss development work on the project
+    url: https://groups.google.com/a/arduino.cc/g/developers
+    about: Arduino Developers Mailing List

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,8 @@
+---
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/minimal/feature-request.md
+name: Feature request
+about: Suggest an enhancement to this project.
+title: ""
+labels: "type: enhancement"
+assignees: ""
+---


### PR DESCRIPTION
Although providing a structured template for filling information into an issue report is not appropriate for this project, the [GitHub issue template](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) system offers some additional useful features for automating issue tracker maintenance tasks:

- [Template chooser](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) allows redirecting support requests via "Contact Links", and also provides a prominent link to
  security policy to guide vulnerability disclosures.
- Encouraging the reporter to fit their report into a specific issue category results in more clarity.
- Automatic [labeling](https://docs.github.com/issues/using-labels-and-milestones-to-track-work/managing-labels) according to template choice allows the reporter to do the initial classification.

This minimal issue template system provides these benefits without making any changes to the actual issue writing process.

---

A preview of how the system will work can be seen here:

https://github.com/per1234/library-registry-submission-parser/issues/new/choose

Due to that demo being from the staged version in my fork, the `arduino` GitHub organization's security policy link is absent from the chooser, but it will automatically appear in the chooser of this repo.
