### PR TITLE
Use a dedicated output field to indicate request conclusion

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ type accessDataType struct {
 
 // request is the type of the request data.
 type request struct {
+	Conclusion                       string           `json:"conclusion"`                       // Request conclusion.
 	Type                             string           `json:"type"`                             // Request type.
 	ArduinoLintLibraryManagerSetting string           `json:"arduinoLintLibraryManagerSetting"` // Argument to pass to Arduino Lint's --library-manager flag.
 	Submissions                      []submissionType `json:"submissions"`                      // Data for submitted libraries.
@@ -185,7 +186,8 @@ func main() {
 		if accessData.Host == "github.com" && *submitterArgument == accessData.Name {
 			submitterAccess = accessData.Access
 			if submitterAccess == Deny {
-				req.Type = "declined"
+				req.Conclusion = "declined"
+				req.Type = "invalid"
 				req.Error = fmt.Sprintf("Library registry privileges for @%s have been revoked.%%0ASee: %s", *submitterArgument, accessData.Reference)
 			}
 			break
@@ -216,7 +218,7 @@ func main() {
 	}
 	if len(submissionURLs) > 0 && !allowedSubmissions {
 		// If none of the submissions are allowed, decline the request.
-		req.Type = "declined"
+		req.Conclusion = "declined"
 	}
 
 	// Check for duplicates within the submission itself.

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -23,6 +23,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
 @pytest.mark.parametrize(
     "repopath_folder_name,"
     "submitter,"
+    "expected_conclusion,"
     "expected_type,"
     "expected_error,"
     "expected_submissions,"
@@ -32,6 +33,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "submitter-access-allow",
             "AllowUser",
+            "",
             "submission",
             "",
             [
@@ -53,30 +55,33 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
             "submitter-access-deny",
             "DenyUser",
             "declined",
+            "invalid",
             "Library registry privileges for @DenyUser have been revoked.%0ASee: https://example.com",
             None,
             "",
             "",
         ),
-        ("list-deleted-diff", "FooUser", "other", "", None, "", ""),
-        ("list-deleted-diff", "FooUser", "other", "", None, "", ""),
-        ("list-deleted-diff", "FooUser", "other", "", None, "", ""),
-        ("multi-file-diff", "FooUser", "other", "", None, "", ""),
-        ("non-list-diff", "FooUser", "other", "", None, "", ""),
-        ("list-rename-diff", "FooUser", "other", "", None, "", ""),
+        ("list-deleted-diff", "FooUser", "", "other", "", None, "", ""),
+        ("list-deleted-diff", "FooUser", "", "other", "", None, "", ""),
+        ("list-deleted-diff", "FooUser", "", "other", "", None, "", ""),
+        ("multi-file-diff", "FooUser", "", "other", "", None, "", ""),
+        ("non-list-diff", "FooUser", "", "other", "", None, "", ""),
+        ("list-rename-diff", "FooUser", "", "other", "", None, "", ""),
         (
             "no-final-newline-diff",
             "FooUser",
+            "",
             "invalid",
             "Pull request removes newline from the end of a file.%0APlease add a blank line to the end of the file.",
             None,
             "",
             "",
         ),
-        ("removal", "FooUser", "removal", "", None, "", ""),
+        ("removal", "FooUser", "", "removal", "", None, "", ""),
         (
             "modification",
             "FooUser",
+            "",
             "modification",
             "",
             [
@@ -96,6 +101,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "url-error",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -115,6 +121,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "url-404",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -135,6 +142,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
             "all-owner-access-deny",
             "FooUser",
             "declined",
+            "submission",
             "",
             [
                 {
@@ -154,6 +162,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "some-owner-access-deny",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -184,6 +193,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "not-supported-git-host",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -205,6 +215,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "not-git-clone-url",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -225,6 +236,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "already-in-library-manager",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -244,6 +256,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "type-arduino",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -263,6 +276,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "type-partner",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -282,6 +296,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "type-recommended",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -301,6 +316,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "type-contributed",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -321,6 +337,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "no-tags",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -342,6 +359,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "no-library-properties",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -362,6 +380,7 @@ test_data_path = pathlib.Path(__file__).resolve().parent.joinpath("testdata")
         (
             "duplicates-in-submission",
             "FooUser",
+            "",
             "submission",
             "",
             [
@@ -395,6 +414,7 @@ def test_request(
     run_command,
     repopath_folder_name,
     submitter,
+    expected_conclusion,
     expected_type,
     expected_error,
     expected_submissions,
@@ -423,6 +443,7 @@ def test_request(
     assert result.ok
 
     request = json.loads(result.stdout)
+    assert request["conclusion"] == expected_conclusion
     assert request["type"] == expected_type
     assert request["error"] == expected_error
     assert request["submissions"] == expected_submissions


### PR DESCRIPTION
In cases where the request submitter or the submitted repositories are from entities without registry access privileges, the parser can determine the conclusion of the request. When the access control system was implemented, the pre-existing `type` field was used to pass this information. That field is used in two ways:

- Determine the appropriate handling for the request.
- Apply the appropriate labeling to the pull request.

Although the `type` field is suitable for the first of these in the case where the request is declined, it is not very suitable for the second. The reason is that [the labels](https://github.com/arduino/library-registry/labels) are grouped in sets. The type data corresponds to the ["topic" label set](https://github.com/arduino/library-registry/labels?q=topic%3A), while the conclusion corresponds to the ["conclusion" set](https://github.com/arduino/library-registry/labels?q=conclusion%3A+). The PR should be labeled with the appropriate label from each of these sets.

So the request conclusion data is moved to a dedicated `conclusion` output field, leaving the `type` field to be used exclusively for its original purpose.