### PR TITLE
Bump "Licensed" version in dependency license check workflow

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -79,7 +79,7 @@ jobs:
         uses: licensee/setup-licensed@v1.3.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 5.x
 
       - name: Install Go
         uses: actions/setup-go@v5
@@ -136,7 +136,7 @@ jobs:
         uses: licensee/setup-licensed@v1.3.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 5.x
 
       - name: Install Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
The version of the [**Licensed**](https://github.com/licensee/licensed) tool for use in the GitHub Actions workflow is defined via the **github/setup-licensed** action's `version` input.

Previously the action was configured to install version 3.x of the action. That version is significantly outdated. The workflow is hereby updated to use the latest version of **Licensed**.