### PR TITLE
Remove trailing space from dependency license metadata

### DIFF
--- a/.licenses/library-registry-submission-parser/go/github.com/arduino/go-paths-helper.dep.yml
+++ b/.licenses/library-registry-submission-parser/go/github.com/arduino/go-paths-helper.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/arduino/go-paths-helper
 version: v1.12.1
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/arduino/go-paths-helper
 license: gpl-2.0-or-later
 licenses:


### PR DESCRIPTION
The dependency license metadata is generated by the "Licensed" tool. Previous versions of this tool added a trailing space on the `summary` key. Although trailing whitespace in human produced content is not permitted, machine generated content is used as-is, and so these trailing spaces were left in the metadata files.

It seems that the defect in the "Licensed" tool that caused the trailing space was fixed in a recent version because it is now absent in the metadata files produced by the tool. The metadata files are hereby updated to use the format of the version of the "Licensed" tool currently in use.