### PR TITLE
Allow codeberg.org as hosting option

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ var supportedHosts []string = []string{
 	"git.antares.id",
 	"github.com",
 	"gitlab.com",
-  "codeberg.org",
+	"codeberg.org",
 }
 
 // Libraries under these organizations will have the "Arduino" type and be linted with Arduino Lint in the "official" setting.

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ var supportedHosts []string = []string{
 	"git.antares.id",
 	"github.com",
 	"gitlab.com",
+  "codeberg.org",
 }
 
 // Libraries under these organizations will have the "Arduino" type and be linted with Arduino Lint in the "official" setting.

--- a/main.go
+++ b/main.go
@@ -43,10 +43,10 @@ import (
 // Git hosts that are supported for library repositories.
 var supportedHosts []string = []string{
 	"bitbucket.org",
+	"codeberg.org",
 	"git.antares.id",
 	"github.com",
 	"gitlab.com",
-	"codeberg.org",
 }
 
 // Libraries under these organizations will have the "Arduino" type and be linted with Arduino Lint in the "official" setting.


### PR DESCRIPTION
To allow libraries being hosted on some proper FOSS repository hosting,
the codeberg.org hosting should be allowed.

### Additional context

#### Related

- https://github.com/arduino/library-registry/pull/8050#issuecomment-4186839877
- https://github.com/arduino/library-registry/pull/8513
- https://github.com/arduino/library-registry/pull/8734